### PR TITLE
refactor (errors) - the error handling has been improved.

### DIFF
--- a/src/errorHandling.ts
+++ b/src/errorHandling.ts
@@ -1,0 +1,12 @@
+/**
+ * This file just handles some basic error handling logic
+ */
+
+/** Error Codes */
+export enum ErrorCodes {        
+    GENERIC_CLIENT_ERROR    = "Client Error",
+    INTERNAL_SERVER_ERROR   = "Internal Server Error",
+    AUTH_TOKEN_NOT_FOUND    = "Auth Token Not Found",
+    INVALID_AUTH_TOKEN      = "Invalid Auth Token",    
+};
+

--- a/src/fetchAPIs.ts
+++ b/src/fetchAPIs.ts
@@ -2,9 +2,13 @@
  * This file handles the generic logic to fetch the APIs 
  */
 
+import { GraphQLError } from "graphql";
+import { ErrorCodes } from "./errorHandling.js"
+
 /**
  * The URLS needed to fetch the microservices
  */
+
 export const URLS = {
     GROUPS_API: process.env.GROUPS_API ?? "http://mu_groups_ms:8008/api",
     AUTH_API: process.env.AUTH_API ?? "http://mu_auth_ms:5000"
@@ -72,20 +76,24 @@ export const fetchAPI = async <ExpectedType>(
 
         return {
             status,
-            responseBody: responseBody as BodyType<ExpectedType>,
-            err: false
+            responseBody: responseBody as BodyType<ExpectedType>,            
         }
         
     } catch (err) {
         
         let errorString = `error calling the url ${url}:`                
         errorString = (err instanceof Error) ? `${errorString} ${err.name}; \n ${err.message}` : `${errorString} ${err}`        
-        console.error(errorString)
+        console.error(errorString);
+
+        /**
+         * We want to print the error to gateway console, but we do not want to disclose it to the GraphQL API Consumer,
+         * for security purposes.
+         */        
+        throw new GraphQLError(ErrorCodes.INTERNAL_SERVER_ERROR, {
+            extensions: {
+                code: ErrorCodes.INTERNAL_SERVER_ERROR,                
+            }
+        });
         
-        return {
-            status: undefined,
-            responseBody: undefined,
-            err: true
-        }
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { authme, login, Login, logout, signUp, SignUp } from './resolvers/authRe
 import { todosResolver, createTodo } from './resolvers/todoResolvers.js';
 import { CreateGroup, createGroupResolver, groupsResolver } from './resolvers/groupsResolvers.js';
 import { dateScalar } from './customScalars.js';
+import { ErrorCodes } from './errorHandling.js';
 
 // Here, we define our graphql schema
 const typeDefs = `#graphql
@@ -139,6 +140,16 @@ const resolvers = {
 const server = new ApolloServer<Context>({
   typeDefs,
   resolvers,
+  formatError: (error) => {
+    return {
+      message: error.message,
+      path: error.path,
+      extensions: {
+        code: error.extensions?.code || ErrorCodes.INTERNAL_SERVER_ERROR,
+        serviceErrors: error.extensions?.serviceErrors || [],        
+      }
+    }
+  }
 });
 
 const { url } = await startStandaloneServer(server, {


### PR DESCRIPTION
- Errors are mostly handled by trhowing GraphQLErrors, from Apollo
- The message errors have been standarized, and can be expanded if needed
- Internal logic has been majorly hidden from the error display in the errors field of the graphql responses, mainly stack traces