### PR TITLE
Integrate new groups resolvers in the API Gateway and do some refactoring

### DIFF
--- a/src/fetchMicroservices.ts
+++ b/src/fetchMicroservices.ts
@@ -57,7 +57,7 @@ interface FetchMSParams {
  * @returns The API response already processed
  */
 export const fetchMS = async <ExpectedType>(params: FetchMSParams) => {
-    const response = await privateFetchMS<ExpectedType>(params)
+    const response = await unwrappedFetchMS<ExpectedType>(params)
     
     const status = response.status
     const expectedStatus = (!params.expectedStatus) ? 200 : params.expectedStatus
@@ -76,7 +76,7 @@ export const fetchMS = async <ExpectedType>(params: FetchMSParams) => {
  * This is a generic function that wraps js fetch(), providing some aditional features
  * @returns The API response already processed
  */
-const privateFetchMS = async <ExpectedType>(params: FetchMSParams) => {
+export const unwrappedFetchMS = async <ExpectedType>(params: FetchMSParams) => {
     const { url, responseType, method, headers, body, wrapInData } = params;
     try {
         const response = await fetch(url, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { todosResolver, createTodo } from "./resolvers/todoResolvers.js";
 import {
     CreateGroup,
     createGroupResolver,
+    deleteGroupResolver,
+    groupResolver,
     groupsResolver,
 } from "./resolvers/groupsResolvers.js";
 import {
@@ -157,8 +159,12 @@ const typeDefs = `#graphql
 
     type Query {
       authme: User!
+
       todos: [Todo!]!
+
       groups: [Group!]!
+      group(id: ID!): Group!
+
       user(id: ID!): UserProfile!
 
       # Bulk Example
@@ -172,11 +178,17 @@ const typeDefs = `#graphql
     }
 
     type Mutation {
+      # Auth 
       signUp(input: SignUp!): User!
       login(input: Login!): User!
       logout: Boolean!
+
+      # Todos
       createTodo(input: NewTodo!): Todo!
+
+      # Groups microservice
       createGroup(input: NewGroup!): GroupWithoutImage!
+      deleteGroup(id: ID!): Boolean!
 
       # Bulk Example
       generateCompanies: CompaniesResult!
@@ -208,6 +220,7 @@ const resolvers = {
         authme: async (_: any, {}, context: Context) => authme(context),
         todos: () => todosResolver(),
         groups: async () => groupsResolver(),
+        group: async (_: any, { id }: { id: UUID }) => groupResolver(id),
         user: async (_: any, { id }: { id: UUID }) => userResolver(id),
         exampleCompanies: async (_: any, { id }: { id: string }) =>
             exampleCompaniesResolver(id),
@@ -242,6 +255,9 @@ const resolvers = {
         },
         createGroup: async (_: any, { input }: { input: CreateGroup }) => {
             return await createGroupResolver(input);
+        },
+        deleteGroup: async (_: any, { id } : { id: UUID }) => {
+          return await deleteGroupResolver(id)
         },
         generateCompanies: async () => generateCompaniesResolver(),
         generatePeople: async () => generatePeopleResolver(),

--- a/src/resolvers/groupsResolvers.ts
+++ b/src/resolvers/groupsResolvers.ts
@@ -146,3 +146,33 @@ export const createGroupResolver = async (group: CreateGroup) => {
     const data = response.responseBody.data;
     return getJSONFromGroup(data, false)
 };
+
+/**
+ * Resolver for the deleteGroups mutation type
+ * @returns
+ */
+export const deleteGroupResolver = async (id: UUID) => {
+    // If there is an error in the request fetchMS will throw an exception
+    // Otherwise the delete operation was successful
+    await fetchMS<null>({
+        url: `${URLS.GROUPS_MS}/groups/${id}`,
+        method: "DELETE",
+        expectedStatus: 204,
+        responseType: URL_TYPES.NONE
+    })
+
+    return true
+}
+
+/**
+ * Resolver that gets a group given its id
+ * @returns
+ */
+export const groupResolver = async (id: UUID) => {
+    const response = await fetchMS<GroupFromAPI>({
+        url: `${URLS.GROUPS_MS}/groups/${id}`,
+    })
+
+    const group = response.responseBody.data
+    return getJSONFromGroup(group, true)
+}

--- a/src/resolvers/groupsResolvers.ts
+++ b/src/resolvers/groupsResolvers.ts
@@ -3,14 +3,16 @@
  */
 import { UUID } from "node:crypto";
 import { Buffer } from "node:buffer";
-import { fetchMS, URL_TYPES, URLS } from "../fetchMicroservices.js";
+import { fetchMS, unwrappedFetchMS, URL_TYPES, URLS } from "../fetchMicroservices.js";
 import { Image } from "../types.js";
+import { GraphQLError } from "graphql";
+import { ErrorCodes } from "../errorHandling.js";
 
 interface Group {
     id: UUID;
     name: string;
     description: string;
-    profilePic: Image;
+    profilePic?: Image;
     isVerified: boolean;
     isOpen: boolean;
     createdAt: Date;
@@ -34,9 +36,26 @@ export interface CreateGroup {
     isOpen: boolean;
 }
 
-const getImage = async (url: string) => {
-    const response = await fetchMS({ url, responseType: URL_TYPES.JPEG });
 
+
+const getImage = async (url: string) => {
+    // It is necessary to use unwrappedFetchMS because fetchMS doesn't return a status code when throwing
+    // a GraphQLError, so we can't know if it failed because of a 404 and return null in that case
+    const response = await unwrappedFetchMS({ url, responseType: URL_TYPES.JPEG })
+
+    // TODO: ideally the backend should return some default image when a group doesn't
+    // have one, instead of having to return null here. This would also let us use fetchMS in getImage
+    if ( response.status == 404 ) {
+        return null
+    }
+    if ( response.status != 200 ) {
+        throw new GraphQLError(ErrorCodes.GENERIC_CLIENT_ERROR, {
+            extensions: {
+                code: ErrorCodes.GENERIC_CLIENT_ERROR,
+            },
+        });
+    }
+    
     const body = response.responseBody as Buffer;
     return body.toString("base64");
 };


### PR DESCRIPTION
The groups_ms has two new endpoints: get a group by its id and delete a group (by its id). I created the corresponding query and mutation. I also refactored some code in the group resolvers.
I noticed that the groups resolver threw an error when it couldn't fetch an image, even though profilePics are optional, so I fixed it and now they are indeed optional.